### PR TITLE
[FIX] Traces failing when multibyte

### DIFF
--- a/src/Submission/DaemonSegmentSubmitter.php
+++ b/src/Submission/DaemonSegmentSubmitter.php
@@ -52,7 +52,7 @@ class DaemonSegmentSubmitter implements SegmentSubmitter
     public function submitSegment(Segment $segment)
     {
         $packet = $this->buildPacket($segment);
-        $packetLength = strlen($packet);
+        $packetLength = mb_strlen($packet);
 
         if ($packetLength > self::MAX_SEGMENT_SIZE) {
             $this->submitFragmented($segment);
@@ -77,7 +77,7 @@ class DaemonSegmentSubmitter implements SegmentSubmitter
      */
     private function sendPacket(string $packet): void
     {
-        socket_sendto($this->socket, $packet, strlen($packet), 0, $this->host, $this->port);
+        socket_sendto($this->socket, $packet, mb_strlen($packet), 0, $this->host, $this->port);
     }
 
     /**


### PR DESCRIPTION
AWS doesn't show traces when they contain multibyte chars as the response length is wrong, resulting in a malformed payload